### PR TITLE
Feature: Critical point check for the tangent function

### DIFF
--- a/src/calculator/internal/evaluator.ts
+++ b/src/calculator/internal/evaluator.ts
@@ -1,6 +1,6 @@
 import Decimal from "decimal.js";
+import { err, ok, Ok, Result } from "neverthrow";
 import { isMatching, match, P, Pattern } from "ts-pattern";
-import { ok, err, Ok, Result } from "neverthrow";
 
 import { AngleUnit } from "..";
 import { Token } from "./tokeniser";
@@ -8,6 +8,7 @@ import { Token } from "./tokeniser";
 const PI = Decimal.acos(-1);
 const E = Decimal.exp(1);
 const RAD_DEG_RATIO = new Decimal(180).div(PI);
+const TAN_PRECISION = new Decimal(1).div("1_000_000");
 
 export type SyntaxErrorId = "UNEXPECTED_EOF" | "UNEXPECTED_TOKEN" | "NO_LHS_BRACKET" | "NO_RHS_BRACKET";
 export type EvalResult = Result<Decimal, SyntaxErrorId>;
@@ -89,17 +90,31 @@ export default function evaluate(tokens: Token[], ans: Decimal, ind: Decimal, an
 				return expect({ type: "lbrk" }, false).andThen(() => {
 					const result = evalExpr(Infinity);
 					if (result.isErr()) return result;
-
 					const argument = result.value;
 
-					if (angleUnit === "rad") return ok(func(argument));
+					const { any, union } = P;
 
-					return ok(
-						match(funcName)
-							.with("sin", "cos", "tan", () => func(degToRad(argument)))
-							.with("asin", "acos", "atan", () => radToDeg(func(argument)))
-							.otherwise(() => func(argument))
-					);
+					return match([angleUnit, funcName])
+						.with(["deg", union("sin", "cos")], () => ok(func(degToRad(argument))))
+						.with(["deg", union("asin", "acos", "atan")], () => ok(radToDeg(func(argument))))
+						.with([any, "tan"], () => {
+							const argInRads = angleUnit === "deg" ? degToRad(argument) : argument;
+
+							// Tangent is undefined when the tangent line is parallel to the x-axis,
+							// since parallel lines, by definition, don't cross.
+							// The tangent is parallel when the argument is $ pi/2 + n × pi $ where
+							// $ n $ is an integer. Since we use an approximation for pi, we can only
+							// check if the argument is "close enough" to being an integer.
+							const coefficient = argInRads.sub(PI.div(2)).div(PI);
+							const distFromCriticalPoint = coefficient.sub(coefficient.round()).abs();
+							console.log(coefficient.toString(), distFromCriticalPoint.toString());
+							const isArgCritical = distFromCriticalPoint.lt(TAN_PRECISION);
+
+							if (isArgCritical) return err("UNEXPECTED_EOF" as const);
+
+							return ok(func(argInRads));
+						})
+						.otherwise(() => ok(func(argument)));
 				});
 			})
 			.otherwise(() => err("UNEXPECTED_TOKEN"));


### PR DESCRIPTION
The maths division asked us for clearer output for critical points in the tangent function (`tan(90° + n × 180°)` for any integer `n`). Since we don't do symbolic calculation, all trig calculations use an approximation for `π`, which means the calculator gives an output for these inputs even though they aren't defined (the tangent line for `tan(90°)` is parallel with the x-axis and parallel lines by definition never cross). This PR adds a check for *very big* or *very small* output values for the tangent function and then handles them like they're an error in the input; this seems to be what many other numerical calculators seem to do too — there's no perfect solution without symbolic computation.