### PR TITLE
Add support for superscript exponents in calculator

### DIFF
--- a/src/calculator/internal/evaluator.spec.ts
+++ b/src/calculator/internal/evaluator.spec.ts
@@ -41,6 +41,23 @@ run("Basic operations", [
 	[[litr(1), t.pow, litr(1)], d(1)],
 ]);
 
+run("Superscript exponents", [
+	[[litr(2), t.spow2], d(4)],
+	[[litr(3), t.spow3], d(27)],
+	[[litr(5), t.spow1], d(5)],
+	[[litr(10), t.spow0], d(1)],
+	[[litr(2), t.spow4], d(16)],
+	[[litr(3), t.spow2], d(9)],
+	// Multi-digit superscripts
+	[[litr(2), t.spow10], d(1024)], // 2^10 = 1024
+	[[litr(3), t.spow44], d(3).pow(44)], // 3^44 (huge number)
+	// Test precedence - superscript should have same precedence as ^ operator
+	[[litr(2), t.add, litr(3), t.spow2], d(2).add(d(3).pow(2))], // 2 + 3² = 2 + 9 = 11
+	[[litr(2), t.mul, litr(3), t.spow2], d(2).mul(d(3).pow(2))], // 2 × 3² = 2 × 9 = 18
+	// Mixed with regular exponents
+	[[litr(2), t.spow2, t.pow, litr(2)], d(2).pow(2).pow(2)], // 2²^2 = 4^2 = 16
+]);
+
 run("Associativity", [
 	[[litr(4), t.add, litr(3), t.add, litr(2), t.add, litr(1)], d(4).add(3).add(2).add(1)],
 	[[litr(4), t.sub, litr(3), t.sub, litr(2), t.sub, litr(1)], d(4).sub(3).sub(2).sub(1)],

--- a/src/calculator/internal/evaluator.ts
+++ b/src/calculator/internal/evaluator.ts
@@ -168,6 +168,7 @@ export default function evaluate(tokens: Token[], ans: Decimal, ind: Decimal, an
 				.with({ type: "oper", name: "*" }, () => evalExpr(3).map(right => left.value.mul(right)))
 				.with({ type: "oper", name: "/" }, () => evalExpr(3).map(right => left.value.div(right)))
 				.with({ type: "oper", name: "^" }, () => evalExpr(3).map(right => left.value.pow(right)))
+				.with({ type: "spow" }, (token: Token<"spow">) => ok(left.value.pow(token.value))) // Superscript power
 				// Right bracket should never get parsed by anything else than the left bracket parselet
 				.with({ type: "rbrk" }, () => err("NO_LHS_BRACKET" as const))
 				.otherwise(() => err("UNEXPECTED_TOKEN"))
@@ -223,6 +224,7 @@ function lbp(token: Token) {
 		.with({ type: "oper", name: P.union("+", "-") }, () => 2)
 		.with({ type: "oper", name: P.union("*", "/") }, () => 3)
 		.with({ type: "oper", name: "^" }, () => 4)
+		.with({ type: "spow" }, () => 4) // Same precedence as ^ operator
 		.with({ type: "func" }, () => 5)
 		.exhaustive();
 }

--- a/src/calculator/internal/tokeniser.spec.ts
+++ b/src/calculator/internal/tokeniser.spec.ts
@@ -46,6 +46,21 @@ run("Brackets", [["2+(3+4)", [litr(2), t.add, t.lbrk, litr(3), t.add, litr(4), t
 run("Semicolons", [["(8;3;2;1)", [t.lbrk, litr(8), t.semi, litr(3), t.semi, litr(2), t.semi, litr(1), t.rbrk]]]);
 run("Functions", [["sin cos tan root", [t.sin, t.cos, t.tan, t.root]]]);
 run("Memory", [["ans mem", [t.ans, t.ind]]]);
+run("Superscript", [
+	["2²", [litr(2), t.spow2]],
+	["5¹", [litr(5), t.spow1]],
+	["10⁰", [litr(10), t.spow0]],
+	["3⁴", [litr(3), t.spow4]],
+	["2⁵", [litr(2), t.spow5]],
+	["4⁶", [litr(4), t.spow6]],
+	["7⁷", [litr(7), t.spow7]],
+	["8⁸", [litr(8), t.spow8]],
+	["9⁹", [litr(9), t.spow9]],
+	// Multi-digit superscripts
+	["2¹⁰", [litr(2), t.spow10]],
+	["3⁴⁴", [litr(3), t.spow44]],
+	["5¹²³", [litr(5), t.spow123]],
+]);
 
 function run(title: string, cases: [input: string, expected: Token[]][]) {
 	describe(title, () => {

--- a/src/calculator/internal/tokeniser.ts
+++ b/src/calculator/internal/tokeniser.ts
@@ -59,6 +59,32 @@ const tokenMatchers = [
 		}),
 	],
 	[
+		// Superscript numbers as exponents: "²", "³", "¹", "⁴⁴", etc.
+		// These will be converted to "^2", "^3", "^1", "^44", etc.
+		// Multiple superscript digits are treated as a single multi-digit exponent
+		/^[⁰¹²³⁴⁵⁶⁷⁸⁹]+/,
+		str => {
+			const superscriptMap: Record<string, string> = {
+				'⁰': '0',
+				'¹': '1', 
+				'²': '2',
+				'³': '3',
+				'⁴': '4',
+				'⁵': '5',
+				'⁶': '6',
+				'⁷': '7',
+				'⁸': '8',
+				'⁹': '9'
+			};
+			// Convert each superscript character to its regular digit
+			const digits = str.split('').map(char => superscriptMap[char] || char).join('');
+			return {
+				type: "spow" as const,
+				value: new Decimal(digits),
+			};
+		},
+	],
+	[
 		// Operators: "-", "+", "/", "*", "^"
 		// The multiplication and minus signs have unicode variants that also need to be handled
 		/^[-+/*^−×]/,

--- a/src/utils/prettify-expression.spec.ts
+++ b/src/utils/prettify-expression.spec.ts
@@ -40,6 +40,25 @@ run("Negative numbers", [
 	["-(5+5)", "-(5 + 5)"],
 ]);
 
+run("Superscript exponents", [
+	["2²", "2²"],
+	["3³", "3³"], 
+	["5¹", "5¹"],
+	["10⁰", "10⁰"],
+	["4⁶", "4⁶"],
+	["7⁷", "7⁷"],
+	["8⁸", "8⁸"],
+	["9⁹", "9⁹"],
+	// Multi-digit superscripts
+	["2¹⁰", "2¹⁰"],
+	["3⁴⁴", "3⁴⁴"],
+	["5¹²³", "5¹²³"],
+	// Should have no space before superscript
+	["2 + 3²", "2 + 3²"],
+	["(2 + 3)²", "(2 + 3)²"],
+	["2 × 3¹⁰", "2 × 3¹⁰"],
+]);
+
 describe("Arithmetic character rewrites", () => {
 	// Running these in their own block so the names are more descriptive than "5 - 5 => 5 − 5"
 	test("Minus", () => expect(prettify("5-5")).toBe("5 − 5"));

--- a/src/utils/prettify-expression.ts
+++ b/src/utils/prettify-expression.ts
@@ -51,6 +51,25 @@ function* prettiedCharacters(tokens: Token[]) {
 			.with({ type: "oper", name: "*" }, () => "×")
 			.with({ type: "oper", name: "-" }, () => "−")
 			.with({ type: "oper", name: any }, token => token.name)
+			.with({ type: "spow" }, token => {
+				// Convert the decimal value back to superscript characters
+				const numberMap: Record<string, string> = {
+					'0': '⁰',
+					'1': '¹', 
+					'2': '²',
+					'3': '³',
+					'4': '⁴',
+					'5': '⁵',
+					'6': '⁶',
+					'7': '⁷',
+					'8': '⁸',
+					'9': '⁹'
+				};
+				// Convert each digit to its superscript equivalent
+				const digits = token.value.toString();
+				const superscript = digits.split('').map((digit: string) => numberMap[digit] || digit).join('');
+				return superscript || `^${token.value.toString()}`;
+			})
 			.with({ type: "func", name: any }, token =>
 				match(token.name)
 					.with("sqrt", () => "√")
@@ -77,6 +96,8 @@ function* prettiedCharacters(tokens: Token[]) {
 					[any, { type: "func" }, { type: "lbrk" }],
 					// Negative numbers: e.g. "-5" and "-5 + 5" instead of "- 5" and "- 5 + 5"
 					[not({ type: union("litr", "cons", "memo", "rbrk") }), { type: "oper", name: "-" }, any],
+					// No space before superscript: "5²" instead of "5 ²"
+					[any, { type: "spow" }, any],
 					// No space at the end
 					[any, any, null],
 					() => false,

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -7,6 +7,7 @@ import { Token, TokenId } from "#/calculator";
  */
 export const T = {
 	litr: (x: number | Decimal) => ({ type: "litr", value: new Decimal(x) }),
+	spow: (x: number | Decimal) => ({ type: "spow", value: new Decimal(x) }),
 
 	oper: (name: Token<"oper">["name"]) => ({ type: "oper", name }),
 	memo: (name: Token<"memo">["name"]) => ({ type: "memo", name }),
@@ -29,6 +30,19 @@ export const t = {
 	mul: T.oper("*"),
 	div: T.oper("/"),
 	pow: T.oper("^"),
+	spow0: T.spow(0),
+	spow1: T.spow(1),
+	spow2: T.spow(2),
+	spow3: T.spow(3),
+	spow4: T.spow(4),
+	spow5: T.spow(5),
+	spow6: T.spow(6),
+	spow7: T.spow(7),
+	spow8: T.spow(8),
+	spow9: T.spow(9),
+	spow10: T.spow(10),
+	spow44: T.spow(44),
+	spow123: T.spow(123),
 	sin: T.func("sin"),
 	cos: T.func("cos"),
 	tan: T.func("tan"),

--- a/test_superscript.js
+++ b/test_superscript.js
@@ -1,0 +1,20 @@
+import { tokenise } from "./src/calculator/internal/tokeniser.js";
+import { evaluate } from "./src/calculator/internal/evaluator.js";
+import { prettify } from "./src/utils/prettify-expression.js";
+
+// Test single digit superscripts
+console.log("Testing single digit superscripts:");
+console.log("2² =", tokenise("2²"));
+console.log("3³ =", tokenise("3³"));
+console.log("5¹ =", tokenise("5¹"));
+
+// Test multi-digit superscripts
+console.log("\nTesting multi-digit superscripts:");
+console.log("2¹⁰ =", tokenise("2¹⁰"));
+console.log("3⁴⁴ =", tokenise("3⁴⁴"));
+console.log("5¹²³ =", tokenise("5¹²³"));
+
+// Test prettification
+console.log("\nTesting prettification:");
+console.log("2² prettifies to:", prettify("2²"));
+console.log("2¹⁰ prettifies to:", prettify("2¹⁰"));


### PR DESCRIPTION
Introduces parsing, evaluation, and pretty-printing for superscript exponents (e.g., ², ³, ¹⁰) in expressions. Tokeniser now recognizes multi-digit superscript numbers, evaluator computes them with correct precedence, and prettify-expression displays them as superscripts. Includes new tests and utility token definitions for superscript powers.

Improves UX on operating systems that automatically turn e.g. ^2 into ².