### PR TITLE
feat: add absolute function

### DIFF
--- a/src/calculator/internal/evaluator.spec.ts
+++ b/src/calculator/internal/evaluator.spec.ts
@@ -126,6 +126,7 @@ run("Functions", [
 	[[t.log10, t.lbrk, litr(13),  t.add, litr(13),  t.rbrk], Decimal.log10(2 * 13)],
 	[[t.sqrt,  t.lbrk, litr(13),  t.add, litr(13),  t.rbrk], Decimal.sqrt(2 * 13)],
 	[[t.root,  t.lbrk, litr(4),   t.add, litr(4), t.semi, litr(3), t.rbrk], d(2)],
+	[[t.abs,  t.lbrk, litr(-4),   t.add, litr(-4), t.rbrk], d(8)],
 
 	[
 		[ // sin((2 / 3) * pi) ^ sqrt(1.08 + 7.12)

--- a/src/calculator/internal/evaluator.ts
+++ b/src/calculator/internal/evaluator.ts
@@ -118,6 +118,12 @@ export default function evaluate(tokens: Token[], ans: Decimal, ind: Decimal, an
 										: radicand.pow(ONE.div(degree)),
 							);
 						})
+						.with("abs", () => {
+							if (args.length < 1) return err("NOT_ENOUGH_ARGS" as const);
+							if (args.length > 1) return err("TOO_MANY_ARGS" as const);
+
+							return ok(args[0]!.abs());
+						})
 						.otherwise(funcName => {
 							if (args.length < 1) return err("NOT_ENOUGH_ARGS" as const);
 							if (args.length > 1) return err("TOO_MANY_ARGS" as const);

--- a/src/calculator/internal/tokeniser.spec.ts
+++ b/src/calculator/internal/tokeniser.spec.ts
@@ -44,7 +44,7 @@ run("Disregard trailing zeros", [
 run("Operators", [["2+3", [litr(2), t.add, litr(3)]]]);
 run("Brackets", [["2+(3+4)", [litr(2), t.add, t.lbrk, litr(3), t.add, litr(4), t.rbrk]]]);
 run("Semicolons", [["(8;3;2;1)", [t.lbrk, litr(8), t.semi, litr(3), t.semi, litr(2), t.semi, litr(1), t.rbrk]]]);
-run("Functions", [["sin cos tan root", [t.sin, t.cos, t.tan, t.root]]]);
+run("Functions", [["sin cos tan root abs", [t.sin, t.cos, t.tan, t.root, t.abs]]]);
 run("Memory", [["ans mem", [t.ans, t.ind]]]);
 
 function run(title: string, cases: [input: string, expected: Token[]][]) {

--- a/src/calculator/internal/tokeniser.ts
+++ b/src/calculator/internal/tokeniser.ts
@@ -125,6 +125,7 @@ const tokenMatchers = [
 				/^((a(rc)?)?(sin|cos|tan))/,
 				/^(log|lg|ln)/,
 				/^(root|sqrt|√)/,
+				/^(abs)/,
 			]
 				.map(subRegex => subRegex.source)
 				.join("|"),
@@ -139,6 +140,7 @@ const tokenMatchers = [
 				.with("arcsin", () => "asin" as const)
 				.with("arccos", () => "acos" as const)
 				.with("arctan", () => "atan" as const)
+				.with("abs", () => "abs" as const)
 				.otherwise(name => {
 					throw Error(`Programmer error: neglected function "${name}"`);
 				}),

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -44,4 +44,5 @@ export const t = {
 	lbrk: T.lbrk(),
 	rbrk: T.rbrk(),
 	semi: T.semi(),
+	abs: T.func("abs"),
 };


### PR DESCRIPTION
this pr adds a new function that takes the absolute value of whatever is passed in as its first argument. i haven't added a graphical button for it yet because i'm not sure where you would like it to be, the current keypad is kind of full.
would be nice if we also had support for `||` notation. unit tests are included and passing, i can't do my own end to end testing because of the babel clsx plugin.

i have signed and sent you the CLA via email, but you have not responded yet.